### PR TITLE
Restore lambda_runtime to example following update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.2", features = ["macros", "rt-multi-thread"] }
-lamedh_runtime = "0.3.0"
+lambda_runtime = "0.3.0"
 simple_logger = "1.11.0"
 rusoto_core = "0.46.0"
 rusoto_ssm = "0.46.0"

--- a/examples/contact_lambda.rs
+++ b/examples/contact_lambda.rs
@@ -8,7 +8,7 @@
 //! are completed concurrently by using async functions.
 //!
 
-use lamedh_runtime::{handler_fn, run, Error};
+use lambda_runtime::{handler_fn, run, Error};
 #[cfg(feature = "logging")]
 use log::LevelFilter;
 #[cfg(feature = "logging")]
@@ -48,7 +48,7 @@ fn get_environment_level() -> LevelFilter {
 
 mod handler {
     use hcaptcha::Hcaptcha;
-    use lamedh_runtime::{Context, Error};
+    use lambda_runtime::{Context, Error};
     #[cfg(feature = "logging")]
     use log::{debug, error};
     use rusoto_core::Region;


### PR DESCRIPTION
Change to use  updated version of lambda_runtime in example code.