### PR TITLE
Add feature flag to build reqwest with rustsl backend

### DIFF
--- a/hcaptcha/Cargo.toml
+++ b/hcaptcha/Cargo.toml
@@ -22,9 +22,9 @@ include = [
 ]
 
 [features]
-default = ["ext", "openssl-backend"]
+default = ["ext", "nativetls-backend"]
 rustsl-backend = ["reqwest/rustls-tls"]
-openssl-backend = ["reqwest/native-tls"]
+nativetls-backend = ["reqwest/native-tls"]
 ext = ["hex"]
 enterprise = []
 trace = ["tracing"]

--- a/hcaptcha/Cargo.toml
+++ b/hcaptcha/Cargo.toml
@@ -22,8 +22,9 @@ include = [
 ]
 
 [features]
-default = ["ext"]
+default = ["ext", "openssl-backend"]
 rustsl-backend = ["reqwest/rustls-tls"]
+openssl-backend = ["reqwest/native-tls"]
 ext = ["hex"]
 enterprise = []
 trace = ["tracing"]
@@ -32,7 +33,7 @@ nightly = []
 [dependencies]
 async-trait = "0.1"
 hex = { version = "0.4", optional = true }
-reqwest = { version = "0.11.12", features = ["json"] }
+reqwest = { version = "0.11.12",default-features=false, features = ["json"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/hcaptcha/Cargo.toml
+++ b/hcaptcha/Cargo.toml
@@ -23,6 +23,7 @@ include = [
 
 [features]
 default = ["ext"]
+rustsl-backend = ["reqwest/rustls-tls"]
 ext = ["hex"]
 enterprise = []
 trace = ["tracing"]

--- a/hcaptcha/src/lib.rs
+++ b/hcaptcha/src/lib.rs
@@ -301,7 +301,7 @@
 //! * `enterprise` - Enable methods to access enterprise service fields in the  `HcaptchaResponse`
 //! * `ext` - Enables extended validation of secret
 //! * `trace` - Enables tracing instrumentation on all functions. Traces are logged at the debug level. The value of the secret is not logged.
-//! * `nativetls-backend` - Enables native-tls backend in reqwuests
+//! * `nativetls-backend` - Enables native-tls backend in reqwests
 //! * `rustsl-backend` - Enables rustsl backend in reqwests
 //! # Rust Version
 //!

--- a/hcaptcha/src/lib.rs
+++ b/hcaptcha/src/lib.rs
@@ -289,8 +289,8 @@
 //! ```
 //! # Feature Flags
 //!
-//! The default library includes extended validation for the secret field.
-//! Disable this validation by setting default-features = false.
+//! The default library includes extended validation for the secret field and use of native TLS as the TLS backend
+//! Disable this validation by setting default-features = false and to enable rustls features=["rustls"]
 //!
 //! ```toml
 //! [dependency]
@@ -301,7 +301,8 @@
 //! * `enterprise` - Enable methods to access enterprise service fields in the  `HcaptchaResponse`
 //! * `ext` - Enables extended validation of secret
 //! * `trace` - Enables tracing instrumentation on all functions. Traces are logged at the debug level. The value of the secret is not logged.
-//!
+//! * `nativetls-backend` - Enables native-tls backend in reqwuests
+//! * `rustsl-backend` - Enables rustsl backend in reqwests
 //! # Rust Version
 //!
 //! This version of hcaptcha requires Rust v1.46 or later.


### PR DESCRIPTION
This pull request addresses #370 by adding a feature flag to build reqwest with rutls as a back end over  openssl. I've found that there is no issue with using it as a backend as due to reqwests high level design its just a matter of setting feature flags